### PR TITLE
fix resolution of time field contained in transformations.pcd

### DIFF
--- a/src/lidar_odometry/mapOptmization.cpp
+++ b/src/lidar_odometry/mapOptmization.cpp
@@ -367,7 +367,7 @@ public:
         unused = system((std::string("mkdir ") + savePCDDirectory).c_str()); ++unused;
         // save key frame transformations
         pcl::io::savePCDFileASCII(savePCDDirectory + "trajectory.pcd", *cloudKeyPoses3D);
-        pcl::io::savePCDFileASCII(savePCDDirectory + "transformations.pcd", *cloudKeyPoses6D);
+        pcl::io::savePCDFileBinary(savePCDDirectory + "transformations.pcd", *cloudKeyPoses6D);
         // extract global point cloud map        
         pcl::PointCloud<PointType>::Ptr globalCornerCloud(new pcl::PointCloud<PointType>());
         pcl::PointCloud<PointType>::Ptr globalSurfCloud(new pcl::PointCloud<PointType>());


### PR DESCRIPTION
Hi @TixiaoShan, I was trying to read in the trajectory from `transformations.pcd` for the handheld dataset and noticed that when saved to ASCII, the time field in `cloudKeyPoses6D` is rounded to a value that can no longer be used. Here is example output of the time field (in ros time format) when reading in the transformations for the first five frames of the handheld dataset:

```
1594310400.000000000
1594310400.000000000
1594310400.000000000
1594310400.000000000
1594310400.000000000
```
when saved to binary, the time field reads:
```
1594310479.546099424
1594310481.361608505
1594310482.975419998
1594310484.185739517
1594310484.992564201
```
I am reading in transformations using code similar to what is shown below, where `PointXYZIRPYT` is defined [here](https://github.com/adthoms/LVI-SAM/blob/5941aaaeb0a710db307b43865b2a6289660b6d26/src/lidar_odometry/mapOptmization.cpp#L29)
```
pcl::PointCloud<PointXYZIRPYT>::Ptr cloud(new pcl::PointCloud<PointXYZIRPYT>);

  // load PCD
  int pcl_loaded =
      pcl::io::loadPCDFile<PointXYZIRPYT>(path_to_transformations_pcd, *cloud);
``` 
Let me know if this fix is suitable. 
